### PR TITLE
Fixed 'Namespace not specified' error in Gradle 8 (Resolve Issue #5)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.imlian.flutter_asa_attribution'
+    }
+
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
It resolves [this issue](https://github.com/lianshumin/flutter_asa_attribution/issues/5)